### PR TITLE
determine the user's group from /etc/passwd

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -39,7 +39,7 @@ def install_bashd(user,home)
   # Create dir for bash scriptlets
   directory "#{home}/.bash.d" do
     user user
-    group user
+    group Etc.getpwnam(user).gid
     mode 0775
   end
 

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -38,7 +38,7 @@ action :create do
     source new_resource.source if new_resource.source
     mode 0755
     user buser
-    group buser
+    group Etc.getpwnam(buser).gid
     variables(new_resource.variables)
   end  
 end


### PR DESCRIPTION
This reads the actual group id from /etc/passwd rather than relying on the user and group name being equal. All tests still passing.